### PR TITLE
Pauses as expected now

### DIFF
--- a/index.babel
+++ b/index.babel
@@ -23,6 +23,7 @@ const deadCell = {
 }
 
 var pause = 0;
+var delayOneSec;
 
 class LivingTile extends React.Component {
   constructor(props) {
@@ -105,7 +106,7 @@ class Board extends React.Component {
 
   componentDidUpdate() {
     if (pause === 0) {
-      setTimeout(this.nextGeneration, 1000);
+      delayOneSec = setTimeout(this.nextGeneration, 1000);
     }
   }
 
@@ -113,8 +114,10 @@ class Board extends React.Component {
       this.createStatus();
   }
 
+  //pauses or resumes the game
   pause() {
     if (pause === 0) {
+      clearTimeout(delayOneSec);
       pause = 1;
     } else {
       pause = 0;

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ var deadCell = {
 };
 
 var _pause = 0;
+var delayOneSec;
 
 var LivingTile = function (_React$Component) {
   _inherits(LivingTile, _React$Component);
@@ -152,7 +153,7 @@ var Board = function (_React$Component3) {
     key: 'componentDidUpdate',
     value: function componentDidUpdate() {
       if (_pause === 0) {
-        setTimeout(this.nextGeneration, 1000);
+        delayOneSec = setTimeout(this.nextGeneration, 1000);
       }
     }
   }, {
@@ -160,10 +161,14 @@ var Board = function (_React$Component3) {
     value: function componentDidMount() {
       this.createStatus();
     }
+
+    //pauses or resumes the game
+
   }, {
     key: 'pause',
     value: function pause() {
       if (_pause === 0) {
+        clearTimeout(delayOneSec);
         _pause = 1;
       } else {
         _pause = 0;


### PR DESCRIPTION
The board pauses immediatly now. Previously one more generation would
iterate after pause was pressed.